### PR TITLE
Allow `Uri::open()` to be called from any thread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,6 +189,7 @@ version = "0.2.0"
 dependencies = [
  "block2",
  "cfg-if",
+ "dispatch2",
  "jni",
  "log",
  "objc2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ robius-android-env = "0.2.0"
 
 [target.'cfg(target_os = "ios")'.dependencies]
 block2 = "0.6.1"
+dispatch2 = { version = "0.3.0", default-features = false, features = ["std", "objc2"] }
 objc2 = "0.6.1"
 objc2-foundation = { version = "0.3.1", default-features = false, features = ["alloc", "NSDictionary", "NSObject", "NSString", "NSURL"] }
 objc2-ui-kit     = { version = "0.3.1", default-features = false, features = ["alloc", "block2", "UIApplication", "UIResponder"] }

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,7 +9,7 @@ pub enum Error {
     AndroidEnvironment,
     #[cfg(target_os = "android")]
     Java(jni::errors::Error),
-    /// The provided URI was malformed.
+    /// The provided URI was malformed or otherwise invalid.
     MalformedUri,
     /// No handler was available to open the URI.
     NoHandler,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,7 @@ impl<'a, 'b> Uri<'a, 'b> {
     pub fn open(self) -> Result<()> {
         self.open_with_completion(|_success| {
             #[cfg(feature = "log")]
-            log::debug!("Called on_completion closure with success: {}", _success);
+            log::debug!("Uri::open(): called on_completion closure, success: {}", _success);
         })
     }
 
@@ -118,8 +118,8 @@ impl<'a, 'b> Uri<'a, 'b> {
     /// Thus, the URI was *not* successfully opened if this function returns an error,
     /// **OR** if the `on_completion` callback is invoked with `false`.
     pub fn open_with_completion<F>(self, on_completion: F) -> Result<()>
-    where 
-        F: Fn(bool) + 'static,
+    where
+        F: Fn(bool) + Send + 'static,
     {
         // Passing an empty URI can cause your app to be killed on certain platforms.
         if self.inner.is_empty() {

--- a/src/sys/android.rs
+++ b/src/sys/android.rs
@@ -24,7 +24,7 @@ impl<'a, 'b> Uri<'a, 'b> {
     }
 
     pub fn open<F>(self, on_completion: F) -> Result<()>
-    where 
+    where
         F: Fn(bool) + 'static,
     {
         let res = robius_android_env::with_activity(|env, current_activity| {

--- a/src/sys/ios.rs
+++ b/src/sys/ios.rs
@@ -1,9 +1,11 @@
 use std::marker::PhantomData;
 
 use block2::RcBlock;
+use dispatch2::run_on_main;
 use objc2_foundation::{NSDictionary, NSString, NSURL};
-use objc2::{MainThreadMarker, runtime::Bool};
+use objc2::runtime::Bool;
 use objc2_ui_kit::UIApplication;
+
 
 use crate::{Error, Result};
 
@@ -30,33 +32,29 @@ impl<'a, 'b> Uri<'a, 'b> {
 
     pub fn open<F>(self, on_completion: F) -> Result<()>
     where
-        F: Fn(bool) + 'static,
+        F: Fn(bool) + Send + 'static,
     {
-        let block = RcBlock::new(move |success: Bool| {
-            #[cfg(feature = "log")]
-            log::warn!("Calling on_completion closure with success: {}", success.as_raw());
+        // iOS requires that we call openURL on the main thread.
+        run_on_main(move |mtm| {
+            let string = NSString::from_str(self.inner);
+            let url = unsafe { NSURL::URLWithString(&string) }
+                .ok_or(Error::MalformedUri)?;
+            let application = UIApplication::sharedApplication(mtm);
+    
+            let block = RcBlock::new(move |success: Bool| {
+                #[cfg(feature = "log")]
+                log::trace!("Calling on_completion closure with success: {}", success.as_raw());
+                on_completion(success.into());
+            });
 
-            on_completion(success.into());
-        });
-
-        let string = NSString::from_str(self.inner);
-        let url = unsafe { NSURL::URLWithString(&string) }
-            .ok_or(Error::MalformedUri)?;
-        let mtm = MainThreadMarker::new().ok_or(Error::NotMainThread)?;
-        let application = UIApplication::sharedApplication(mtm);
-
-        #[cfg(feature = "log")]
-        log::warn!("Calling application.openURL()");
-
-        unsafe {
-            application.openURL_options_completionHandler(
-                &url,
-                &NSDictionary::new(), // no options used currently.
-                Some(&block),
-            );
-        }
-        #[cfg(feature = "log")]
-        log::warn!("After application.openURL(). Returning Ok(())");
-        Ok(())
+            unsafe {
+                application.openURL_options_completionHandler(
+                    &url,
+                    &NSDictionary::new(), // no options used currently.
+                    Some(&block),
+                );
+            }
+            Ok(())
+        })
     }
 }

--- a/src/sys/macos.rs
+++ b/src/sys/macos.rs
@@ -27,7 +27,7 @@ impl<'a, 'b> Uri<'a, 'b> {
     }
 
     pub fn open<F>(self, on_completion: F) -> Result<()>
-    where 
+    where
         F: Fn(bool) + 'static,
     {
         let string = NSString::from_str(self.inner);

--- a/src/sys/unsupported.rs
+++ b/src/sys/unsupported.rs
@@ -22,6 +22,8 @@ impl<'a, 'b> Uri<'a, 'b> {
     }
 
     pub fn open(self) -> Result<()> {
+        #[cfg(feature = "log")]
+        log::error!("Failed to open URI; this platform is unsupported.");
         Err(Error::Unknown)
     }
 }


### PR DESCRIPTION
on iOS, it will dispatch the `openUrl` call to the main UI thread, which is why the trait bounds for the `on_completion` callback have been made more strict with `+ Send`.