### PR TITLE
Fix unsupported open() method signature

### DIFF
--- a/src/sys/unsupported.rs
+++ b/src/sys/unsupported.rs
@@ -21,9 +21,13 @@ impl<'a, 'b> Uri<'a, 'b> {
         self
     }
 
-    pub fn open(self) -> Result<()> {
+    pub fn open<F>(self, on_completion: F) -> Result<()>
+    where
+        F: Fn(bool) + 'static,
+    {
         #[cfg(feature = "log")]
         log::error!("Failed to open URI; this platform is unsupported.");
+        on_completion(false);
         Err(Error::Unknown)
     }
 }


### PR DESCRIPTION
### Changes

Fixes WASM compilation error by adding missing `on_completion` callback parameter to unsupported platform's `open()` method.